### PR TITLE
Update BattlescapeState.cpp

### DIFF
--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -2625,6 +2625,33 @@ inline void BattlescapeState::handle(Action *action)
 				{
 					saveVoxelView();
 				}
+				
+				// inspect alien
+				if (key == SDLK_F1 && ctrlPressed)
+				{
+					_battleGame->cancelCurrentAction();
+					BattleUnit* bu = nullptr;
+					Position newPos;
+					_map->getSelectorPosition(&newPos);
+					Tile* tile = _save->getTile(newPos);
+					if (tile)
+					{
+						bu = tile->getOverlappingUnit(_save);
+
+						if (bu && (bu->getVisible() || _save->getDebugMode()))
+						{
+							if (_save->getDebugMode() && (SDL_GetModState() & KMOD_CTRL) != 0)
+							{
+								// mind probe
+								popup(new UnitInfoState(bu, this, false, true));
+							}
+							else
+							{
+								_game->pushState(new AlienInventoryState(bu));
+							}
+						}
+					}				
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Add Key Combo CTRL + F1 for inspecting alien status/inventory

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->